### PR TITLE
solved list index out of range

### DIFF
--- a/zh-hans/basics_data_structure/heap.md
+++ b/zh-hans/basics_data_structure/heap.md
@@ -42,7 +42,10 @@ class MaxHeap:
         left, right = 2 * i + 1, 2 * i + 2
         max_index = i
         # should compare two chidren then determine which one to swap with
-        flag = array[left] > array[right] 
+        if left < len(array) and right < len(array):
+            flag = array[left] > array[right]
+        else:
+            flag = True
         if left < len(array) and array[left] > array[max_index] and flag:
             max_index = left
         if right < len(array) and array[right] > array[max_index] and not flag:


### PR DESCRIPTION
python代码 flag = array[left] > array[right] 没有判断 left 和 right 的大小，可能会越界。
例: [6, 8, 7, 4, 5, 3, 2, 1]